### PR TITLE
Update Put Logic

### DIFF
--- a/lib/facet.test.ts
+++ b/lib/facet.test.ts
@@ -175,16 +175,17 @@ describe('Facet', () => {
 	});
 
 	test('Delete Pages', async () => {
-		const firstPage = await PageFacet.get({
-			pageId: mockPageIds[0],
-		});
+		const [pageToDelete] = mockPages(1);
+		const putPageResult = await PageFacet.put(pageToDelete);
 
-		if (!firstPage) {
-			throw Error('Unable to get the first page');
+		expect(putPageResult.wasSuccessful).toBeTruthy();
+
+		if (!putPageResult.wasSuccessful) {
+			throw Error('Unable to put the page to delete');
 		}
 
 		const deleteResult = await PageFacet.delete({
-			pageId: firstPage.pageId,
+			pageId: putPageResult.record.pageId,
 		});
 
 		expect(deleteResult.deleted.length).toBe(1);

--- a/lib/facet.ts
+++ b/lib/facet.ts
@@ -18,7 +18,13 @@ export type Validator<T> = (input: unknown) => T;
 import zlib from 'zlib';
 import { getBatchItems, getSingleItem } from './get';
 import { PartitionQuery } from './query';
-import { putItems, PutOptions, PutResponse, putSingleItem } from './put';
+import {
+	putItems,
+	PutOptions,
+	PutResponse,
+	putSingleItem,
+	PutSingleItemResponse,
+} from './put';
 import { ConverterOptions } from '@faceteer/converter/converter-options';
 import {
 	deleteItems,
@@ -560,7 +566,10 @@ export class Facet<
 	 * Put a record into the Dynamo DB table
 	 * @param records
 	 */
-	async put(record: T, options?: PutOptions<T>): Promise<PutResponse<T>>;
+	async put(
+		record: T,
+		options?: PutOptions<T>,
+	): Promise<PutSingleItemResponse<T>>;
 	/**
 	 * Put multiple records into the Dynamo DB table
 	 * @param records
@@ -569,7 +578,7 @@ export class Facet<
 	async put(
 		records: T[] | T,
 		options?: PutOptions<T>,
-	): Promise<PutResponse<T>> {
+	): Promise<PutResponse<T> | PutSingleItemResponse<T>> {
 		if (Array.isArray(records)) {
 			return putItems(this, records);
 		}


### PR DESCRIPTION
This is a major change since it will break clients.

## 1. Return the actual put object
It's possible to use a Validator to modify objects before we put them into the database. The current put logic will return the item/items that were given to the function, not the modified result that's being put into DynamoDB.

## 2. Return a different response type when putting single items
Currently the `put()` operation always returns an array of records, whether you put an array of records or not.

Now it will return a different type depending on whether or not an array of items are passed in.