### PR TITLE
Fix put conditions without attribute names or values

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
   dynamodb-local:
     command: "-jar DynamoDBLocal.jar -inMemory -sharedDb"
     image: "amazon/dynamodb-local:latest"
-    container_name: dynamodb-local
     ports:
       - "8000:8000"
     working_dir: /home/dynamodblocal

--- a/lib/facet.test.ts
+++ b/lib/facet.test.ts
@@ -201,6 +201,28 @@ describe('Facet', () => {
 
 		// expect(allPages.length).toBe(5);
 	});
+
+	test('Conditional Puts', async () => {
+		const testPage: Page = {
+			accessToken: 'ZZZZZZZZZZZZ',
+			pageId: 'ZZZZZZZZZZZZ',
+			pageName: 'ZZZZZZZZZZZZ',
+			tokenStatus: TokenStatus.Failed,
+		};
+
+		await PageFacet.delete({ pageId: testPage.pageId });
+		const successfulPut = await PageFacet.put(testPage, {
+			condition: ['pageId', 'not_exists'],
+		});
+
+		expect(successfulPut.wasSuccessful).toBeTruthy();
+
+		const failedPut = await PageFacet.put(testPage, {
+			condition: ['pageId', 'not_exists'],
+		});
+
+		expect(failedPut.wasSuccessful).toBeFalsy();
+	});
 });
 
 function mockPages(count: number, overrides: Partial<Page> = {}): Page[] {

--- a/lib/put.ts
+++ b/lib/put.ts
@@ -68,8 +68,12 @@ export async function putSingleItem<T, PK extends keyof T, SK extends keyof T>(
 		if (options.condition) {
 			const expression = condition(options.condition);
 			putInput.ConditionExpression = expression.expression;
-			putInput.ExpressionAttributeNames = expression.names;
-			putInput.ExpressionAttributeValues = expression.values;
+			if (Object.keys(expression.names).length > 0) {
+				putInput.ExpressionAttributeNames = expression.names;
+			}
+			if (Object.keys(expression.values).length > 0) {
+				putInput.ExpressionAttributeValues = expression.values;
+			}
 		}
 
 		await facet.connection.dynamoDb.putItem(putInput);


### PR DESCRIPTION
Previously, writing a statement like this would throw an error.

```ts
const failedPut = await PageFacet.put(testPage, {
  condition: ['pageId', 'not_exists'],
});
```

This was because the AWS Dynamo DB SDK doesn't accept an empty object when specifying `ExpressionAttributeNames` or `ExpressionAttributeValues`. It must be undefined, or an object with records in it.

The fix was to just check and make sure we actually had expression attributes before applying them to the put requests.