### PR TITLE
Bump `cbor` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@faceteer/converter": "^2.0.3",
     "@faceteer/expression-builder": "^2.0.1",
-    "cbor": "^7.0.5",
+    "cbor": "^8.1.0",
     "crc-32": "^1.2.0"
   }
 }


### PR DESCRIPTION
Bumps `cbor` version to fix issues while deploying

![image](https://user-images.githubusercontent.com/11020347/149246379-7cd1b69c-f019-46cf-a6b6-6a05b992db29.png)
