### PR TITLE
Exclude PK and SK from query filter options

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "useTabs": true,
+  "trailingComma": "all",
+  "bracketSpacing": true
+}


### PR DESCRIPTION
According to the AWS docs (see below), PKs and SKs cannot be used in filter expressions. This PR changes the type passed into `QueryOptions` so that it omits those types for better autocomplete.

Under "Filter Expressions for Query":
> A filter expression cannot contain partition key or sort key attributes. You need to specify those attributes in the key condition expression, not the filter expression.

Reference: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html#Query.FilterExpression%7CAWS