### PR TITLE
Include all keys of union types

### DIFF
--- a/lib/delete.ts
+++ b/lib/delete.ts
@@ -1,9 +1,9 @@
 import type { WriteRequest, DeleteItemInput } from '@aws-sdk/client-dynamodb';
-import type { Facet, Keys } from './facet';
+import type { Facet } from './facet';
 import { wait } from './wait';
 import { Converter } from '@faceteer/converter';
 import expressionBuilder from '@faceteer/expression-builder';
-import { PK, SK } from './keys';
+import { PK, SK, Keys } from './keys';
 
 export interface DeleteOptions<T> {
 	condition?: expressionBuilder.ConditionExpression<T>;

--- a/lib/delete.ts
+++ b/lib/delete.ts
@@ -1,5 +1,5 @@
 import type { WriteRequest, DeleteItemInput } from '@aws-sdk/client-dynamodb';
-import type { Facet } from './facet';
+import type { Facet, Keys } from './facet';
 import { wait } from './wait';
 import { Converter } from '@faceteer/converter';
 import expressionBuilder from '@faceteer/expression-builder';
@@ -43,8 +43,8 @@ export interface DeleteResponse<T> {
 
 export async function deleteSingleItem<
 	T,
-	PK extends keyof T,
-	SK extends keyof T,
+	PK extends Keys<T>,
+	SK extends Keys<T>,
 	U = Pick<T, PK | SK> & Partial<T>,
 >(
 	facet: Facet<T, PK, SK>,
@@ -98,8 +98,8 @@ export async function deleteSingleItem<
  */
 export async function deleteItems<
 	T,
-	PK extends keyof T,
-	SK extends keyof T,
+	PK extends Keys<T>,
+	SK extends Keys<T>,
 	U = Pick<T, PK | SK> & Partial<T>,
 >(facet: Facet<T, PK, SK>, records: U[]): Promise<DeleteResponse<U>> {
 	const recordsToBatch: U[] = [...records];
@@ -151,8 +151,8 @@ export async function deleteItems<
  */
 async function deleteBatch<
 	T,
-	PK extends keyof T,
-	SK extends keyof T,
+	PK extends Keys<T>,
+	SK extends Keys<T>,
 	U = Pick<T, PK | SK> & Partial<T>,
 >(facet: Facet<T, PK, SK>, batchToDelete: U[]): Promise<DeleteResponse<U>> {
 	const deleteRequests: Record<string, WriteRequest> = {};

--- a/lib/facet.ts
+++ b/lib/facet.ts
@@ -15,6 +15,7 @@ import {
 	KeyConfiguration,
 	PK,
 	SK,
+	Keys,
 } from './keys';
 import {
 	putItems,
@@ -28,8 +29,6 @@ import { PartitionQuery } from './query';
 export interface AttributeMap {
 	[key: string]: AttributeValue;
 }
-
-export type Keys<T> = T extends T ? keyof T : never;
 
 /**
  * A `Validator` is a function that is used by Faceteer whenever

--- a/lib/facet.ts
+++ b/lib/facet.ts
@@ -29,6 +29,8 @@ export interface AttributeMap {
 	[key: string]: AttributeValue;
 }
 
+export type Keys<T> = T extends T ? Keys<T> : never;
+
 /**
  * A `Validator` is a function that is used by Faceteer whenever
  * it reads records from Dynamo DB.
@@ -72,10 +74,10 @@ export type Validator<T> = (input: unknown) => T;
 
 export type FacetIndexKeys<
 	T,
-	PK extends keyof T,
-	SK extends keyof T,
-	GSIPK extends keyof T,
-	GSISK extends keyof T,
+	PK extends Keys<T>,
+	SK extends Keys<T>,
+	GSIPK extends Keys<T>,
+	GSISK extends Keys<T>,
 	I extends Index,
 	A extends string = never,
 > = Record<I, FacetIndex<T, PK, SK, GSIPK, GSISK>> &
@@ -146,8 +148,8 @@ export type FacetWithIndex<F, K> = F & K;
  */
 export class Facet<
 	T,
-	PK extends keyof T = keyof T,
-	SK extends keyof T = keyof T,
+	PK extends Keys<T> = Keys<T>,
+	SK extends Keys<T> = Keys<T>,
 > {
 	#PK: KeyConfiguration<T, PK>;
 	#SK: KeyConfiguration<T, SK>;
@@ -167,7 +169,7 @@ export class Facet<
 	/**
 	 * The property thats used for the TTL column in Dynamo DB
 	 */
-	readonly ttl?: keyof T;
+	readonly ttl?: Keys<T>;
 	/**
 	 * The configured connection to Dynamo DB
 	 */
@@ -395,8 +397,8 @@ export class Facet<
 	 */
 	addIndex<
 		I extends Index,
-		GSIPK extends keyof T,
-		GSISK extends keyof T,
+		GSIPK extends Keys<T>,
+		GSISK extends Keys<T>,
 		A extends string,
 	>({
 		PK,
@@ -442,8 +444,8 @@ export class Facet<
 export interface AddIndexOptions<
 	T,
 	I extends Index,
-	GSIPK extends keyof T,
-	GSISK extends keyof T,
+	GSIPK extends Keys<T>,
+	GSISK extends Keys<T>,
 	A extends string,
 > {
 	index: I;
@@ -454,10 +456,10 @@ export interface AddIndexOptions<
 
 export class FacetIndex<
 	T,
-	PK extends keyof T = keyof T,
-	SK extends keyof T = keyof T,
-	GSIPK extends keyof T = keyof T,
-	GSISK extends keyof T = keyof T,
+	PK extends Keys<T> = Keys<T>,
+	SK extends Keys<T> = Keys<T>,
+	GSIPK extends Keys<T> = Keys<T>,
+	GSISK extends Keys<T> = Keys<T>,
 > {
 	#facet: Facet<T, PK, SK>;
 	#PK: KeyConfiguration<T, GSIPK>;
@@ -510,7 +512,7 @@ export class FacetIndex<
 /**
  * Options for configuring a Faceteer Facet
  */
-export interface FacetOptions<T, PK extends keyof T, SK extends keyof T> {
+export interface FacetOptions<T, PK extends Keys<T>, SK extends Keys<T>> {
 	/**
 	 * How to build the partition key
 	 * for this facet in the table
@@ -546,7 +548,7 @@ export interface FacetOptions<T, PK extends keyof T, SK extends keyof T> {
 	 * An optional key that should be used as the TTL key
 	 * in Dynamo DB
 	 */
-	ttl?: keyof T;
+	ttl?: Keys<T>;
 
 	/**
 	 * Tells converter to use `iso` or `unix` format

--- a/lib/facet.ts
+++ b/lib/facet.ts
@@ -29,7 +29,7 @@ export interface AttributeMap {
 	[key: string]: AttributeValue;
 }
 
-export type Keys<T> = T extends T ? Keys<T> : never;
+export type Keys<T> = T extends T ? keyof T : never;
 
 /**
  * A `Validator` is a function that is used by Faceteer whenever

--- a/lib/get.ts
+++ b/lib/get.ts
@@ -2,8 +2,8 @@ import type {
 	KeysAndAttributes,
 	BatchGetItemOutput,
 } from '@aws-sdk/client-dynamodb';
-import type { Facet, Keys } from './facet';
-import { PK, SK } from './keys';
+import type { Facet } from './facet';
+import { PK, SK, Keys } from './keys';
 import { wait } from './wait';
 
 export async function getSingleItem<T, PK extends Keys<T>, SK extends Keys<T>>(

--- a/lib/get.ts
+++ b/lib/get.ts
@@ -2,11 +2,11 @@ import type {
 	KeysAndAttributes,
 	BatchGetItemOutput,
 } from '@aws-sdk/client-dynamodb';
-import type { Facet } from './facet';
+import type { Facet, Keys } from './facet';
 import { PK, SK } from './keys';
 import { wait } from './wait';
 
-export async function getSingleItem<T, PK extends keyof T, SK extends keyof T>(
+export async function getSingleItem<T, PK extends Keys<T>, SK extends Keys<T>>(
 	facet: Facet<T, PK, SK>,
 	query: Partial<T>,
 ) {
@@ -42,7 +42,7 @@ export async function getSingleItem<T, PK extends keyof T, SK extends keyof T>(
  * the batches only have a maximum of 100 items
  * @param queries
  */
-export async function getBatch<T, PK extends keyof T, SK extends keyof T>(
+export async function getBatch<T, PK extends Keys<T>, SK extends Keys<T>>(
 	facet: Facet<T, PK, SK>,
 	queries: Partial<T>[],
 ): Promise<T[]> {
@@ -135,7 +135,7 @@ export async function getBatch<T, PK extends keyof T, SK extends keyof T>(
  * batches of 100 if needed
  * @param queries
  */
-export async function getBatchItems<T, PK extends keyof T, SK extends keyof T>(
+export async function getBatchItems<T, PK extends Keys<T>, SK extends Keys<T>>(
 	facet: Facet<T, PK, SK>,
 	queries: Partial<T>[],
 ): Promise<T[]> {
@@ -168,7 +168,7 @@ export async function getBatchItems<T, PK extends keyof T, SK extends keyof T>(
  * @param keys
  * @returns
  */
-async function getBatchKeys<T, PK extends keyof T, SK extends keyof T>(
+async function getBatchKeys<T, PK extends Keys<T>, SK extends Keys<T>>(
 	keys: KeysAndAttributes['Keys'],
 	facet: Facet<T, PK, SK>,
 ) {

--- a/lib/keys.ts
+++ b/lib/keys.ts
@@ -1,5 +1,6 @@
-import type { Keys } from './facet';
 import { crcShard } from './hash/crc-shard';
+
+export type Keys<T> = T extends T ? keyof T : never;
 
 /**
  * How to shard a key into multiple groups

--- a/lib/keys.ts
+++ b/lib/keys.ts
@@ -1,10 +1,11 @@
+import type { Keys } from './facet';
 import { crcShard } from './hash/crc-shard';
 
 /**
  * How to shard a key into multiple groups
  */
 export interface ShardConfiguration<T> {
-	keys: (keyof T)[];
+	keys: Keys<T>[];
 	count: number;
 }
 
@@ -97,7 +98,7 @@ export function isIndex(indexName: string): indexName is Index {
 /**
  * How to build a composite key from an object
  */
-export interface KeyConfiguration<T, U extends keyof T> {
+export interface KeyConfiguration<T, U extends Keys<T>> {
 	/**
 	 * An array of object keys that will be used
 	 * to create the composite key.
@@ -147,8 +148,8 @@ export const IndexKeyNameMap = {
  */
 export interface IndexKeyConfiguration<
 	T,
-	P extends keyof T,
-	K extends keyof T,
+	P extends Keys<T>,
+	K extends Keys<T>,
 > {
 	PK: KeyConfiguration<T, P>;
 	SK: KeyConfiguration<T, K>;
@@ -161,46 +162,46 @@ export interface IndexKeyConfiguration<
  */
 export interface IndexKeyOptions<
 	T,
-	GSI1PK extends keyof T = never,
-	GSI1SK extends keyof T = never,
-	GSI2PK extends keyof T = never,
-	GSI2SK extends keyof T = never,
-	GSI3PK extends keyof T = never,
-	GSI3SK extends keyof T = never,
-	GSI4PK extends keyof T = never,
-	GSI4SK extends keyof T = never,
-	GSI5PK extends keyof T = never,
-	GSI5SK extends keyof T = never,
-	GSI6PK extends keyof T = never,
-	GSI6SK extends keyof T = never,
-	GSI7PK extends keyof T = never,
-	GSI7SK extends keyof T = never,
-	GSI8PK extends keyof T = never,
-	GSI8SK extends keyof T = never,
-	GSI9PK extends keyof T = never,
-	GSI9SK extends keyof T = never,
-	GSI10PK extends keyof T = never,
-	GSI10SK extends keyof T = never,
-	GSI11PK extends keyof T = never,
-	GSI11SK extends keyof T = never,
-	GSI12PK extends keyof T = never,
-	GSI12SK extends keyof T = never,
-	GSI13PK extends keyof T = never,
-	GSI13SK extends keyof T = never,
-	GSI14PK extends keyof T = never,
-	GSI14SK extends keyof T = never,
-	GSI15PK extends keyof T = never,
-	GSI15SK extends keyof T = never,
-	GSI16PK extends keyof T = never,
-	GSI16SK extends keyof T = never,
-	GSI17PK extends keyof T = never,
-	GSI17SK extends keyof T = never,
-	GSI18PK extends keyof T = never,
-	GSI18SK extends keyof T = never,
-	GSI19PK extends keyof T = never,
-	GSI19SK extends keyof T = never,
-	GSI20PK extends keyof T = never,
-	GSI20SK extends keyof T = never,
+	GSI1PK extends Keys<T> = never,
+	GSI1SK extends Keys<T> = never,
+	GSI2PK extends Keys<T> = never,
+	GSI2SK extends Keys<T> = never,
+	GSI3PK extends Keys<T> = never,
+	GSI3SK extends Keys<T> = never,
+	GSI4PK extends Keys<T> = never,
+	GSI4SK extends Keys<T> = never,
+	GSI5PK extends Keys<T> = never,
+	GSI5SK extends Keys<T> = never,
+	GSI6PK extends Keys<T> = never,
+	GSI6SK extends Keys<T> = never,
+	GSI7PK extends Keys<T> = never,
+	GSI7SK extends Keys<T> = never,
+	GSI8PK extends Keys<T> = never,
+	GSI8SK extends Keys<T> = never,
+	GSI9PK extends Keys<T> = never,
+	GSI9SK extends Keys<T> = never,
+	GSI10PK extends Keys<T> = never,
+	GSI10SK extends Keys<T> = never,
+	GSI11PK extends Keys<T> = never,
+	GSI11SK extends Keys<T> = never,
+	GSI12PK extends Keys<T> = never,
+	GSI12SK extends Keys<T> = never,
+	GSI13PK extends Keys<T> = never,
+	GSI13SK extends Keys<T> = never,
+	GSI14PK extends Keys<T> = never,
+	GSI14SK extends Keys<T> = never,
+	GSI15PK extends Keys<T> = never,
+	GSI15SK extends Keys<T> = never,
+	GSI16PK extends Keys<T> = never,
+	GSI16SK extends Keys<T> = never,
+	GSI17PK extends Keys<T> = never,
+	GSI17SK extends Keys<T> = never,
+	GSI18PK extends Keys<T> = never,
+	GSI18SK extends Keys<T> = never,
+	GSI19PK extends Keys<T> = never,
+	GSI19SK extends Keys<T> = never,
+	GSI20PK extends Keys<T> = never,
+	GSI20SK extends Keys<T> = never,
 > {
 	GSI1?: IndexKeyConfiguration<T, GSI1PK, GSI1SK>;
 	GSI2?: IndexKeyConfiguration<T, GSI2PK, GSI2SK>;
@@ -227,7 +228,7 @@ export interface IndexKeyOptions<
  * Build a composite primary or sort key based on the key
  * configuration and a model
  */
-export function buildKey<T, U extends keyof T>(
+export function buildKey<T, U extends Keys<T>>(
 	keyConfig: KeyConfiguration<T, U>,
 	model: Partial<T>,
 	delimiter: string,

--- a/lib/put.ts
+++ b/lib/put.ts
@@ -1,5 +1,5 @@
 import type { PutItemInput, WriteRequest } from '@aws-sdk/client-dynamodb';
-import type { Facet } from './facet';
+import type { Facet, Keys } from './facet';
 import { wait } from './wait';
 import { Converter } from '@faceteer/converter';
 import { condition, ConditionExpression } from '@faceteer/expression-builder';
@@ -53,7 +53,7 @@ export interface PutSingleItemResponse<T> {
 	error?: unknown;
 }
 
-export async function putSingleItem<T, PK extends keyof T, SK extends keyof T>(
+export async function putSingleItem<T, PK extends Keys<T>, SK extends Keys<T>>(
 	facet: Facet<T, PK, SK>,
 	record: T,
 	options: PutOptions<T> = {},
@@ -95,7 +95,7 @@ export async function putSingleItem<T, PK extends keyof T, SK extends keyof T>(
  * Put records into the Dynamo DB table
  * @param records
  */
-export async function putItems<T, PK extends keyof T, SK extends keyof T>(
+export async function putItems<T, PK extends Keys<T>, SK extends Keys<T>>(
 	facet: Facet<T, PK, SK>,
 	records: T[],
 ): Promise<PutResponse<T>> {
@@ -146,7 +146,7 @@ export async function putItems<T, PK extends keyof T, SK extends keyof T>(
  * records or less
  * @param batchToPut
  */
-async function putBatch<T, PK extends keyof T, SK extends keyof T>(
+async function putBatch<T, PK extends Keys<T>, SK extends Keys<T>>(
 	facet: Facet<T, PK, SK>,
 	batchToPut: T[],
 ): Promise<PutResponse<T>> {

--- a/lib/put.ts
+++ b/lib/put.ts
@@ -1,5 +1,6 @@
 import type { PutItemInput, WriteRequest } from '@aws-sdk/client-dynamodb';
-import type { Facet, Keys } from './facet';
+import type { Facet } from './facet';
+import type { Keys } from './keys';
 import { wait } from './wait';
 import { Converter } from '@faceteer/converter';
 import { condition, ConditionExpression } from '@faceteer/expression-builder';

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -1,7 +1,7 @@
 import { decodeCursor, encodeCursor } from './cursor';
-import { Facet, FacetIndex, Keys } from './facet';
+import { Facet, FacetIndex } from './facet';
 import * as expressionBuilder from '@faceteer/expression-builder';
-import { IndexKeyNameMap, PK, SK } from './keys';
+import { IndexKeyNameMap, PK, SK, Keys } from './keys';
 import type { QueryInput } from '@aws-sdk/client-dynamodb';
 
 export interface PartitionQueryOptions<

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -1,15 +1,15 @@
 import { decodeCursor, encodeCursor } from './cursor';
-import { Facet, FacetIndex } from './facet';
+import { Facet, FacetIndex, Keys } from './facet';
 import * as expressionBuilder from '@faceteer/expression-builder';
 import { IndexKeyNameMap, PK, SK } from './keys';
 import type { QueryInput } from '@aws-sdk/client-dynamodb';
 
 export interface PartitionQueryOptions<
 	T,
-	PK extends keyof T,
-	SK extends keyof T,
-	GSIPK extends keyof T,
-	GSISK extends keyof T,
+	PK extends Keys<T>,
+	SK extends Keys<T>,
+	GSIPK extends Keys<T>,
+	GSISK extends Keys<T>,
 > {
 	facet: Facet<T, PK, SK>;
 	partitionIdentifier: Partial<T>;
@@ -64,10 +64,10 @@ export interface QueryOptions<T, PK extends keyof T, SK extends keyof T> {
 
 export class PartitionQuery<
 	T,
-	PK extends keyof T,
-	SK extends keyof T,
-	GSIPK extends keyof T = never,
-	GSISK extends keyof T = never,
+	PK extends Keys<T>,
+	SK extends Keys<T>,
+	GSIPK extends Keys<T> = never,
+	GSISK extends Keys<T> = never,
 > {
 	#facet: Facet<T, PK, SK>;
 	#index?: FacetIndex<T, PK, SK, GSIPK, GSISK>;


### PR DESCRIPTION
Allows facet to use all keys for each type within a union instead of only shared keys.

## Before
![Screen Shot 2022-03-25 at 10 57 29 PM](https://user-images.githubusercontent.com/11020347/160223894-f8c63027-a8eb-404b-bd96-91c01656cacb.png)

## After
![Screen Shot 2022-03-25 at 10 57 50 PM](https://user-images.githubusercontent.com/11020347/160223893-cca29acc-88b9-4400-be98-560e1ec79f70.png)