### PR TITLE
Pin TypeScript Minor Version & Fix TS issue with Object.assign

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,1 @@
+* @faceteer/maintainers

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,10 +54,10 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ matrix.node-version }}
           AWS_SECRET_ACCESS_KEY: ${{ matrix.node-version }}
           AWS_DEFAULT_REGION: "us-east-1"
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          CODECOV_TOKEN: ${{ matrix.node-version == '16.x' && secrets.CODECOV_TOKEN || '' }}
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: mikepenz/action-junit-report@v3
         if: always()
         with:
           files: junit.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,4 +60,4 @@ jobs:
         uses: mikepenz/action-junit-report@v3
         if: always()
         with:
-          files: junit.xml
+          report_paths: ./junit.xml

--- a/lib/facet.test.ts
+++ b/lib/facet.test.ts
@@ -221,6 +221,26 @@ describe('Facet', () => {
 		expect(deleteResult.deleted.length).toBe(1);
 	});
 
+	test('Delete Multiple Pages', async () => {
+		const pagesToDelete = mockPages(101);
+
+		const { put: putPages } = await PageFacet.put(pagesToDelete);
+
+		expect(putPages.length).toEqual(101);
+
+		const pageIdsToDelete = pagesToDelete.map((page) => ({
+			pageId: page.pageId,
+		}));
+
+		const deleteResult = await PageFacet.delete(pageIdsToDelete);
+
+		expect(deleteResult.deleted.length).toEqual(101);
+
+		const expectedMissingPages = await PageFacet.get(pageIdsToDelete);
+
+		expect(expectedMissingPages.length).toEqual(0);
+	});
+
 	test('Conditional Puts', async () => {
 		const testPage: Page = {
 			accessToken: 'ZZZZZZZZZZZZ',

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -157,11 +157,11 @@ export class PartitionQuery<
 			const filterExpression = expressionBuilder.filter(filter);
 			queryInput.FilterExpression = filterExpression.expression;
 			Object.assign(
-				queryInput.ExpressionAttributeNames,
+				queryInput.ExpressionAttributeNames ?? {},
 				filterExpression.names,
 			);
 			Object.assign(
-				queryInput.ExpressionAttributeValues,
+				queryInput.ExpressionAttributeValues ?? {},
 				filterExpression.values,
 			);
 		}
@@ -354,11 +354,11 @@ export class PartitionQuery<
 			const filterExpression = expressionBuilder.filter(filter);
 			queryInput.FilterExpression = filterExpression.expression;
 			Object.assign(
-				queryInput.ExpressionAttributeNames,
+				queryInput.ExpressionAttributeNames ?? {},
 				filterExpression.names,
 			);
 			Object.assign(
-				queryInput.ExpressionAttributeValues,
+				queryInput.ExpressionAttributeValues ?? {},
 				filterExpression.values,
 			);
 		}
@@ -468,11 +468,11 @@ export class PartitionQuery<
 			const filterExpression = expressionBuilder.filter(filter);
 			queryInput.FilterExpression = filterExpression.expression;
 			Object.assign(
-				queryInput.ExpressionAttributeNames,
+				queryInput.ExpressionAttributeNames ?? {},
 				filterExpression.names,
 			);
 			Object.assign(
-				queryInput.ExpressionAttributeValues,
+				queryInput.ExpressionAttributeValues ?? {},
 				filterExpression.values,
 			);
 		}

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -157,11 +157,11 @@ export class PartitionQuery<
 			const filterExpression = expressionBuilder.filter(filter);
 			queryInput.FilterExpression = filterExpression.expression;
 			Object.assign(
-				queryInput.ExpressionAttributeNames ?? {},
+				queryInput.ExpressionAttributeNames!,
 				filterExpression.names,
 			);
 			Object.assign(
-				queryInput.ExpressionAttributeValues ?? {},
+				queryInput.ExpressionAttributeValues!,
 				filterExpression.values,
 			);
 		}
@@ -354,11 +354,11 @@ export class PartitionQuery<
 			const filterExpression = expressionBuilder.filter(filter);
 			queryInput.FilterExpression = filterExpression.expression;
 			Object.assign(
-				queryInput.ExpressionAttributeNames ?? {},
+				queryInput.ExpressionAttributeNames!,
 				filterExpression.names,
 			);
 			Object.assign(
-				queryInput.ExpressionAttributeValues ?? {},
+				queryInput.ExpressionAttributeValues!,
 				filterExpression.values,
 			);
 		}
@@ -468,11 +468,11 @@ export class PartitionQuery<
 			const filterExpression = expressionBuilder.filter(filter);
 			queryInput.FilterExpression = filterExpression.expression;
 			Object.assign(
-				queryInput.ExpressionAttributeNames ?? {},
+				queryInput.ExpressionAttributeNames!,
 				filterExpression.names,
 			);
 			Object.assign(
-				queryInput.ExpressionAttributeValues ?? {},
+				queryInput.ExpressionAttributeValues!,
 				filterExpression.values,
 			);
 		}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	},
 	"homepage": "https://github.com/faceteer/facet#readme",
 	"devDependencies": {
-		"@aws-sdk/client-dynamodb": "^3.0.0",
+		"@aws-sdk/client-dynamodb": ">=3.0.0 <=3.193.0",
 		"@types/jest": "^27.0.1",
 		"@types/node": "^15.6.1",
 		"@typescript-eslint/eslint-plugin": "^4.26.0",
@@ -58,7 +58,7 @@
 		"typescript": "~4.3.2"
 	},
 	"peerDependencies": {
-		"@aws-sdk/client-dynamodb": "^3.0.0"
+		"@aws-sdk/client-dynamodb": ">=3.0.0 <=3.193.0"
 	},
 	"dependencies": {
 		"@faceteer/converter": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,69 +1,69 @@
 {
-  "name": "@faceteer/facet",
-  "version": "4.0.5",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "jest --runInBand --silent --coverage",
-    "test:ci": "jest --ci --runInBand --silent --coverage && codecov",
-    "build:clean": "tsc -b --clean",
-    "build": "tsc -b --clean && tsc -b",
-    "prepublishOnly": "npm run build"
-  },
-  "engines": {
-    "node": ">=12.4.0"
-  },
-  "keywords": [
-    "DynamoDB"
-  ],
-  "files": [
-    "lib/**/*.js",
-    "lib/**/*.d.ts",
-    "index.js",
-    "index.d.ts"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/faceteer/facet.git"
-  },
-  "author": "Alex McKenzie",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/faceteer/facet/issues"
-  },
-  "homepage": "https://github.com/faceteer/facet#readme",
-  "devDependencies": {
-    "@aws-sdk/client-dynamodb": "^3.0.0",
-    "@types/jest": "^27.0.1",
-    "@types/node": "^15.6.1",
-    "@typescript-eslint/eslint-plugin": "^4.26.0",
-    "@typescript-eslint/parser": "^4.26.0",
-    "codecov": "^3.8.2",
-    "eslint": "^7.27.0",
-    "eslint-config-google": "^0.14.0",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-config-standard": "^16.0.1",
-    "eslint-import-resolver-node": "^0.3.2",
-    "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^3.4.0",
-    "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^5.0.0",
-    "jest": "^27.0.6",
-    "jest-junit": "^12.2.0",
-    "prettier": "^2.3.0",
-    "ts-jest": "^27.0.5",
-    "ts-node": "^10.1.0",
-    "typedoc": "^0.22.10",
-    "typescript": "^4.3.2"
-  },
-  "peerDependencies": {
-    "@aws-sdk/client-dynamodb": "^3.0.0"
-  },
-  "dependencies": {
-    "@faceteer/converter": "^2.0.3",
-    "@faceteer/expression-builder": "^2.0.1",
-    "cbor": "^8.1.0",
-    "crc-32": "^1.2.0"
-  }
+	"name": "@faceteer/facet",
+	"version": "4.0.5",
+	"description": "",
+	"main": "index.js",
+	"scripts": {
+		"test": "jest --runInBand --silent --coverage",
+		"test:ci": "jest --ci --runInBand --silent --coverage && codecov",
+		"build:clean": "tsc -b --clean",
+		"build": "tsc -b --clean && tsc -b",
+		"prepublishOnly": "npm run build"
+	},
+	"engines": {
+		"node": ">=12.4.0"
+	},
+	"keywords": [
+		"DynamoDB"
+	],
+	"files": [
+		"lib/**/*.js",
+		"lib/**/*.d.ts",
+		"index.js",
+		"index.d.ts"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/faceteer/facet.git"
+	},
+	"author": "Alex McKenzie",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/faceteer/facet/issues"
+	},
+	"homepage": "https://github.com/faceteer/facet#readme",
+	"devDependencies": {
+		"@aws-sdk/client-dynamodb": "^3.0.0",
+		"@types/jest": "^27.0.1",
+		"@types/node": "^15.6.1",
+		"@typescript-eslint/eslint-plugin": "^4.26.0",
+		"@typescript-eslint/parser": "^4.26.0",
+		"codecov": "^3.8.2",
+		"eslint": "^7.27.0",
+		"eslint-config-google": "^0.14.0",
+		"eslint-config-prettier": "^8.3.0",
+		"eslint-config-standard": "^16.0.1",
+		"eslint-import-resolver-node": "^0.3.2",
+		"eslint-plugin-import": "^2.20.2",
+		"eslint-plugin-node": "^11.1.0",
+		"eslint-plugin-prettier": "^3.4.0",
+		"eslint-plugin-promise": "^4.2.1",
+		"eslint-plugin-standard": "^5.0.0",
+		"jest": "^27.0.6",
+		"jest-junit": "^12.2.0",
+		"prettier": "^2.3.0",
+		"ts-jest": "^27.0.5",
+		"ts-node": "^10.1.0",
+		"typedoc": "^0.22.10",
+		"typescript": "~4.3.2"
+	},
+	"peerDependencies": {
+		"@aws-sdk/client-dynamodb": "^3.0.0"
+	},
+	"dependencies": {
+		"@faceteer/converter": "^2.0.3",
+		"@faceteer/expression-builder": "^2.0.1",
+		"cbor": "^8.1.0",
+		"crc-32": "^1.2.0"
+	}
 }


### PR DESCRIPTION
## TypesScript Version Pinning

Versions of TypeScript over 4.3 are causing build issues with how we're using some of our generics.  

E.g.

```
lib/delete.ts:176:46 - error TS2345: Argument of type 'U' is not assignable to parameter of type 'Partial<T>'.

176   const key = facet.pk(batchItem) + facet.sk(batchItem);
```

## `QueryInput` Type Changes
Also, AWS appears to have changed the type definition of `QueryInput`, marking `ExpressionAttributeNames` as an optional field and breaking the type safety of `Object.assign()`.

The way we're calling it here, `ExpressionAttributeNames` is always initialized, so coalescing to an empty object inside of the `Object.assign()` call works fine to get around the type checks.

## AWS SDK endpoint bug
AWS has a bug in their SDK when setting a custom endpoint for DynamoDB. Pinning the versions gets around this.

https://github.com/aws/aws-sdk-js-v3/issues/4076
