### PR TITLE
release: v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ npm dist-tags track the most recent publish in each channel: `latest` points at 
 
 ## [Unreleased]
 
+## [6.0.0] - 2026-04-20
+
+Stable promotion of `6.0.0-alpha.0`. No behavioral changes to library code; see the `6.0.0-alpha.0` entry for the full set of v6 changes.
+
+### Infrastructure
+
+- Regenerated typedoc output for v6 and added a `docs` npm script.
+- Bumped `actions/checkout` and `actions/setup-node` from v4 to v6 in CI.
+
 ## [6.0.0-alpha.0] - 2026-04-20
 
 First publish of the v6 line. Breaking changes from v5 touch module format, the DynamoDB client wiring, the cursor format, and the public API surface — migrating existing v5 consumers is not a drop-in upgrade.
@@ -61,5 +70,6 @@ First publish of the v6 line. Breaking changes from v5 touch module format, the 
 - Widened `@aws-sdk/client-dynamodb` peer dep range to `^3.0.0`.
 - Shared VS Code workspace setting makes IDE auto-imports insert the required `.js` extension for NodeNext module resolution.
 
-[unreleased]: https://github.com/faceteer/facet/compare/v6.0.0-alpha.0...HEAD
+[unreleased]: https://github.com/faceteer/facet/compare/v6.0.0...HEAD
+[6.0.0]: https://github.com/faceteer/facet/compare/v6.0.0-alpha.0...v6.0.0
 [6.0.0-alpha.0]: https://github.com/faceteer/facet/releases/tag/v6.0.0-alpha.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@faceteer/facet",
-	"version": "6.0.0-alpha.0",
+	"version": "6.0.0",
 	"description": "",
 	"type": "module",
 	"main": "./index.js",


### PR DESCRIPTION
## Summary

- Promote `6.0.0-alpha.0` to stable `6.0.0`. No library behavior change vs. the alpha.
- CHANGELOG: close out `[Unreleased]` as `[6.0.0] - 2026-04-20`, note the typedoc regen and `actions/checkout` + `actions/setup-node` v4→v6 bump as the only delta from alpha.0, open a fresh `[Unreleased]`, update compare links.
- `package.json` version → `6.0.0`.

## Test plan

- [ ] CI green (lint, format:check, typecheck, build, tests on Node 20/22/24 against DynamoDB Local)
- [ ] After merge: `git tag v6.0.0 && git push origin v6.0.0` — publish workflow handles npm (`latest` dist-tag) + GitHub Release sourced from the CHANGELOG section